### PR TITLE
Fixed lowercase volume to Volume in bibliography

### DIFF
--- a/um-plainnat.bst
+++ b/um-plainnat.bst
@@ -451,12 +451,12 @@ FUNCTION {either.or.check}
 FUNCTION {format.bvolume}
 { volume empty$
     { "" }
-    { "volume" volume tie.or.space.connect
+    { "Volume" volume tie.or.space.connect
       series empty$
         'skip$
         { " of " * series emphasize * }
       if$
-      "volume and number" number either.or.check
+      "Volume and Number" number either.or.check
     }
   if$
 }


### PR DESCRIPTION
Fixed the lowercase volume word in the bibliography to capitalised (Volume). Example below.

Example:
Bondy, J. A., Murty, U. S. R., et al. Graph theory with applications, volume 290. Macmillan London, 1976

is now updated to
Bondy, J. A., Murty, U. S. R., et al. Graph theory with applications, Volume 290. Macmillan London, 1976
